### PR TITLE
Fix define in cmakelists and update README with commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ ELSEIF (APPLE)
     third_party/clip/clip_osx.mm
   )
 ELSEIF (UNIX)
-  ADD_COMPILE_DEFINITIONS(-DHAVE_XCB_XLIB_H=1)
+  ADD_COMPILE_DEFINITIONS(HAVE_XCB_XLIB_H=1)
   SET(clip_libs xcb pthread)
   SET(ca_src ${ca_src}
     third_party/clip/clip_x11.cpp

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Compiles in Windows, Linux and Mac.
 
 The Linux and MAC versions are not stable yet: they compile but have some divergences from windows version.
 
+### Clone, compile, run on Linux
+```
+git clone https://github.com/lets-all-be-stupid-forever/circuit-artist.git
+cd circuit-artist/
+git submodule init
+git submodule update
+mkdir build
+cd build/
+cmake ..
+make -C ../LuaJIT/
+make
+ln -s ../LuaJIT/src/libluajit.so libluajit-5.1.so.2
+LD_LIBRARY_PATH=$PWD ./ca
+```
+
+
 ## License
 
 GPLv3. See LICENSE file. For dependencies, see `third_party` folder.


### PR DESCRIPTION
This fixes "error: macro names must be identifiers" and adds exact instructions for cloning, compiling and running on linux.
