### PR TITLE
Fix broken wiki image loading

### DIFF
--- a/assets/files/levels/desc/demux.txt
+++ b/assets/files/levels/desc/demux.txt
@@ -13,7 +13,7 @@ For example:
 !img:levels/demux/tut1.png
 
 A `DEMUX` is like a bit `router`: Given an input bit `a`, 2 outputs `Y0` and `Y1` and a selector bit `s`, if `s` is 0, then set `Y0` to the value of `a` and `Y1` to 0. Otherwise, if `s` is 1, set `Y0` to 0 and `Y1` to the value of `a`.
-!img:imgs/tutorial/demux3.png
+!img:demux3.png
 Demuxes work like routers: you have a wire and the selector bit chooses to which wire the input bit should go.
 Example:
 a=0, s=0 --> Y0 = 0, Y1 = 0

--- a/assets/files/wiki/desc/demux.txt
+++ b/assets/files/wiki/desc/demux.txt
@@ -4,7 +4,7 @@
 !img:demux1.png
 
 A `DEMUX` is like a bit `router`: Given an input bit `a`, 2 outputs `Y0` and `Y1` and a selector bit `s`, if `s` is 0, then set `Y0` to the value of `a` and `Y1` to 0. Otherwise, if `s` is 1, set `Y0` to 0 and `Y1` to the value of `a`.
-!img:imgs/tutorial/demux3.png
+!img:demux3.png
 Demuxes work like routers: you have a wire and the selector bit chooses to which wire the input bit should go.
 Example:
 a=0, s=0 --> Y0 = 0, Y1 = 0

--- a/assets/files/wiki/desc/propdelay.txt
+++ b/assets/files/wiki/desc/propdelay.txt
@@ -6,7 +6,7 @@ Both NAND gates and wires have propagation delay. When you chain components toge
 `When to AVOID clock delay:`
 You should generally avoid adding gates between the clock signal and flip-flop inputs. If some flip-flops receive the clock later than others, your memory will no longer be synchronous and you might have bugs.
 
-!img:imgs/tutorial/sync5.png
+!img:wiki/sync5.png
 
 `When to USE clock delay:`
 However, there are cases where you WANT to delay the clock:

--- a/assets/files/wiki/desc/synchronous.txt
+++ b/assets/files/wiki/desc/synchronous.txt
@@ -6,7 +6,7 @@ In this section, you'll see how to use memory to create `synchronous sequential`
 `Synchronous` as in, every bit storage you have is updated once and at the `same time` for each `enable` cycle. We use a special bit to perform this synchronization, which we call `CLOCK` bit.  Whenever it goes up, the memories are updated (with the current input `D` value, which come from calculations from previous cycle) and it is only updated again when it goes to 0 and back to 1. This forms what we call a `clock cycle`. We can see that the actual "sequential" property of our system is tightly linked with the cycles of the clock: each cycle defines one "update->compute" step in our sequence .
 !img:wiki/sync2.png
 You can structure synchronous circuits in 2 major subcircuits: (i) the `combinatorial` subcircuit and (ii) the `memory` subcircuit:
-!img:imgs/tutorial/sync1.png
+!img:wiki/sync1.png
 The role of the `memory` subcircuit is to store and update the memory of the system. It's very similar to a big D flip flop but instead of a single bit, it stores multiple bits `S`, and the output is just a stored version of the input `S`.
 
 The role of the `combinatorial` subcircuit is to take the previous state `S_prv` as input, as well as some external input bits `Din` and generate both the bits corresponding to the next desired state `S_nxt` and the outputs of the system `Dout`. In this subcircuit there's no memory or "loops", just straight logic computation.

--- a/src/game_registry.c
+++ b/src/game_registry.c
@@ -117,7 +117,7 @@ static int lua_add_level(lua_State* L) {
     return luaL_error(L, "Description field must be a string");
   }
   ldef->description = clone_string(lua_tostring(L, -1));
-  load_text_sprites_v2(root, ldef->description, &ldef->sprites);
+  load_text_sprites(root, ldef->description, &ldef->sprites);
   lua_pop(L, 1);  // Remove icon from stack
 
   /* Name */
@@ -361,7 +361,7 @@ static int lua_tutorial_add_item(lua_State* L) {
   const char* icon = luaL_checkstring(L, 5);
   char* icon2 = checkmodpath(root, icon);
   sprite_t* sprites;
-  load_text_sprites_v2(root, desc, &sprites);
+  load_text_sprites(root, desc, &sprites);
   registry_add_tutorial_item(r, topic_id, id, name, desc, sprites, icon2);
   free(icon2);
   return 0;

--- a/src/game_registry.c
+++ b/src/game_registry.c
@@ -103,12 +103,12 @@ static int lua_add_level(lua_State* L) {
     return luaL_error(L, "icon field must be a string");
   }
   const char* icon = lua_tostring(L, -1);
-  char* icon2 = checkmodpath(root, icon);
-  if (!icon2) {
+  char* icon_path = checkmodpath(root, icon);
+  if (!icon_path) {
     return luaL_error(L, "Invalid icon path");
   }
-  ldef->icon = create_sprite(LoadTexture(icon2));
-  free(icon2);
+  ldef->icon = create_sprite(LoadTexture(icon_path));
+  free(icon_path);
   lua_pop(L, 1);  // Remove icon from stack
 
   /* Description */
@@ -359,11 +359,11 @@ static int lua_tutorial_add_item(lua_State* L) {
   const char* name = luaL_checkstring(L, 3);
   const char* desc = luaL_checkstring(L, 4);
   const char* icon = luaL_checkstring(L, 5);
-  char* icon2 = checkmodpath(root, icon);
+  char* icon_path = checkmodpath(root, icon);
   sprite_t* sprites;
   load_text_sprites(root, desc, &sprites);
-  registry_add_tutorial_item(r, topic_id, id, name, desc, sprites, icon2);
-  free(icon2);
+  registry_add_tutorial_item(r, topic_id, id, name, desc, sprites, icon_path);
+  free(icon_path);
   return 0;
 }
 
@@ -530,8 +530,8 @@ static int find_topic_by_id(GameRegistry* r, const char* topic_id) {
 }
 
 void registry_add_tutorial_topic(GameRegistry* r, const char* topic_id,
-                                 const char* name, const char* icon_file) {
-  assert(FileExists(icon_file));
+                                 const char* name, const char* icon_path) {
+  assert(FileExists(icon_path));
   int idx = find_topic_by_id(r, topic_id);
   if (idx != -1) {
     // TODO Handle this error properly
@@ -541,19 +541,19 @@ void registry_add_tutorial_topic(GameRegistry* r, const char* topic_id,
   TutorialTopic topic = {0};
   topic.id = clone_string(topic_id);
   topic.name = clone_string(name);
-  topic.icon = create_sprite(LoadTexture(icon_file));
+  topic.icon = create_sprite(LoadTexture(icon_path));
   arrput(r->topics, topic);
 }
 
 void registry_add_tutorial_item(GameRegistry* r, const char* topic_id,
                                 const char* item_id, const char* name,
                                 const char* desc, sprite_t* sprites,
-                                const char* icon_file) {
-  assert(FileExists(icon_file));
+                                const char* icon_path) {
+  assert(FileExists(icon_path));
   int idx = find_topic_by_id(r, topic_id);
   TutorialTopic* topic = &r->topics[idx];
   TutorialItem item = {0};
-  item.icon = create_sprite(LoadTexture(icon_file));
+  item.icon = create_sprite(LoadTexture(icon_path));
   item.desc = clone_string(desc);
   item.desc_imgs = sprites;
   item.id = clone_string(item_id);

--- a/src/game_registry.c
+++ b/src/game_registry.c
@@ -107,7 +107,7 @@ static int lua_add_level(lua_State* L) {
   if (!icon2) {
     return luaL_error(L, "Invalid icon path");
   }
-  ldef->icon = load_sprite_asset(icon2);
+  ldef->icon = create_sprite(LoadTexture(icon2));
   free(icon2);
   lua_pop(L, 1);  // Remove icon from stack
 
@@ -541,7 +541,7 @@ void registry_add_tutorial_topic(GameRegistry* r, const char* topic_id,
   TutorialTopic topic = {0};
   topic.id = clone_string(topic_id);
   topic.name = clone_string(name);
-  topic.icon = load_sprite_asset(icon_file);
+  topic.icon = create_sprite(LoadTexture(icon_file));
   arrput(r->topics, topic);
 }
 
@@ -553,7 +553,7 @@ void registry_add_tutorial_item(GameRegistry* r, const char* topic_id,
   int idx = find_topic_by_id(r, topic_id);
   TutorialTopic* topic = &r->topics[idx];
   TutorialItem item = {0};
-  item.icon = load_sprite_asset(icon_file);
+  item.icon = create_sprite(LoadTexture(icon_file));
   item.desc = clone_string(desc);
   item.desc_imgs = sprites;
   item.id = clone_string(item_id);

--- a/src/utils.c
+++ b/src/utils.c
@@ -377,14 +377,6 @@ sprite_t load_sprite_asset(const char* asset) {
                     }};
 }
 
-void load_text_from_file(const char* fname, char** out_txt,
-                         sprite_t** out_sprites) {
-  char* txt = LoadFileText(fname);
-  load_text_sprites(txt, out_sprites);
-  *out_txt = clone_string(txt);
-  UnloadFileText(txt);
-}
-
 static inline bool is_bg(Color c) {
   return (c.r != 255 || c.g != 255 || c.b != 255);
 }
@@ -710,21 +702,6 @@ Rectangle roff(Vector2 off, Rectangle r) {
       r.width,
       r.height,
   };
-}
-
-void load_text_sprites(const char* txt, sprite_t** out_sprites) {
-  const char* nxt = txt;
-  sprite_t* sprites = NULL;
-  while ((nxt = strstr(nxt, "!img:"))) {
-    int i = 5;
-    while (nxt[i] != ' ' && nxt[i] != '\n') i++;
-    char tmp[200];
-    strncpy(tmp, nxt + 5, i - 5);
-    tmp[i - 5] = '\0';
-    arrput(sprites, load_sprite_asset(tmp));
-    nxt = &nxt[3];
-  }
-  *out_sprites = sprites;
 }
 
 void load_text_sprites_v2(const char* root, const char* txt,

--- a/src/utils.c
+++ b/src/utils.c
@@ -355,19 +355,7 @@ void str_builder_destroy(str_builder_t* sb) {
   sb->cap = 0;
 }
 
-sprite_t load_sprite_raw(const char* asset) {
-  Texture tex = LoadTexture(asset);
-  return (sprite_t){.tex = tex,
-                    .region = (Rectangle){
-                        0,
-                        0,
-                        tex.width,
-                        tex.height,
-                    }};
-}
-
-sprite_t load_sprite_asset(const char* asset) {
-  Texture tex = load_texture_asset(asset);
+sprite_t create_sprite(Texture tex) {
   return (sprite_t){.tex = tex,
                     .region = (Rectangle){
                         0,
@@ -716,8 +704,8 @@ void load_text_sprites(const char* root, const char* txt,
     tmp[i - 5] = '\0';
     char* p = checkmodpath(root, tmp);
     assert(p);
-    printf("Loadin sprite %s ...", p);
-    arrput(sprites, load_sprite_raw(p));
+    printf("Loadin sprite %s ...\n", p);
+    arrput(sprites, create_sprite(LoadTexture(p)));
     free(p);
     nxt = &nxt[3];
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -704,8 +704,8 @@ Rectangle roff(Vector2 off, Rectangle r) {
   };
 }
 
-void load_text_sprites_v2(const char* root, const char* txt,
-                          sprite_t** out_sprites) {
+void load_text_sprites(const char* root, const char* txt,
+                       sprite_t** out_sprites) {
   const char* nxt = txt;
   sprite_t* sprites = NULL;
   while ((nxt = strstr(nxt, "!img:"))) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -702,11 +702,11 @@ void load_text_sprites(const char* root, const char* txt,
     char tmp[200];
     strncpy(tmp, nxt + 5, i - 5);
     tmp[i - 5] = '\0';
-    char* p = checkmodpath(root, tmp);
-    assert(p);
-    printf("Loadin sprite %s ...\n", p);
-    arrput(sprites, create_sprite(LoadTexture(p)));
-    free(p);
+    char* tex_path = checkmodpath(root, tmp);
+    assert(tex_path);
+    printf("Loadin sprite %s ...\n", tex_path);
+    arrput(sprites, create_sprite(LoadTexture(tex_path)));
+    free(tex_path);
     nxt = &nxt[3];
   }
   *out_sprites = sprites;

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,8 +29,8 @@ void str_builder_add(str_builder_t* sb, const char* fmt, ...);
 void str_builder_destroy(str_builder_t* sb);
 
 sprite_t load_sprite_asset(const char* fname);
-void load_text_sprites_v2(const char* root, const char* txt,
-                          sprite_t** out_sprites);
+void load_text_sprites(const char* root, const char* txt,
+                       sprite_t** out_sprites);
 void delete_file(const char* path);
 
 /* Hack for layout parsing */

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,8 +29,6 @@ void str_builder_add(str_builder_t* sb, const char* fmt, ...);
 void str_builder_destroy(str_builder_t* sb);
 
 sprite_t load_sprite_asset(const char* fname);
-void load_text_from_file(const char* fname, char** txt, sprite_t** sprites);
-void load_text_sprites(const char* txt, sprite_t** sprites);
 void load_text_sprites_v2(const char* root, const char* txt,
                           sprite_t** out_sprites);
 void delete_file(const char* path);

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,7 +28,7 @@ void str_builder_add_raw(str_builder_t* sb, const char* txt);
 void str_builder_add(str_builder_t* sb, const char* fmt, ...);
 void str_builder_destroy(str_builder_t* sb);
 
-sprite_t load_sprite_asset(const char* fname);
+sprite_t create_sprite(Texture tex);
 void load_text_sprites(const char* root, const char* txt,
                        sprite_t** out_sprites);
 void delete_file(const char* path);


### PR DESCRIPTION
I noticed this issue yesterday but wasn't able to get a PR ready since it was late. You already pushed a partial fix for it which added a `_raw` function, but I opted to keep what I had yesterday.

The main fixes was removing the `load_sprite_*` functions in favor of a `create_sprite` function, since that would avoid duplicating the code. I also found that some paths in the wiki files were broken, after I assume some files were moved around, so fixed those links.

btw, I'm happy to drop any commits you don't want :)